### PR TITLE
Allow custom page transition animation properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,30 @@ var ViewPager = require('react-native-viewpager');
 
 * **`dataSource`**: this is require to provide pages data,
 * **`renderPage`**: this is require to render page view,
-* **`autoPlay`**: `true` to turn page automaticly,
+* **`autoPlay`**: `true` to turn page automatically,
 * **`isLoop`**: `true` to run in infinite scroll mode,
 * **`locked`**: `true` to disable touch scroll,
 * **`onChangePage`**: page change callback,
 * **`renderPageIndicator`**: render custom ViewPager indicator.
+
+## Animated Transition Controls
+
+* **`transitionFriction`**: number or function that returns a number to set custom friction value for animated page transitions.
+* **`transitionTension`**: number or function that returns a number to set custom tension value for animated page transitions.
+
+Example:
+```
+var ViewPager = require('react-native-viewpager');
+<ViewPager
+    dataSource={this.state.dataSource}
+    renderPage={this._renderPage}
+    transitionFriction={10}
+    transitionTension={(vx) => {
+      // function receives the gestureState vx property
+      return vx*100;
+    }}
+/>
+```
 
 ## Licensed
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,25 @@ var ViewPager = require('react-native-viewpager');
 * **`onChangePage`**: page change callback,
 * **`renderPageIndicator`**: render custom ViewPager indicator.
 
+## Animated Transition Controls
+
+* **`transitionFriction`**: number or function that returns a number to set custom friction value for animated page transitions.
+* **`transitionTension`**: number or function that returns a number to set custom tension value for animated page transitions.
+
+Example:
+```
+var ViewPager = require('react-native-viewpager');
+<ViewPager
+    dataSource={this.state.dataSource}
+    renderPage={this._renderPage}
+    transitionFriction={(vx) => {
+      // function receives the gestureState vx property
+      return vx*100;
+    }}
+    transitionTension={10}
+/>
+```
+
 ## Licensed
 
 MIT License

--- a/README.md
+++ b/README.md
@@ -48,19 +48,11 @@ var ViewPager = require('react-native-viewpager');
 <ViewPager
     dataSource={this.state.dataSource}
     renderPage={this._renderPage}
-<<<<<<< HEAD
     transitionFriction={10}
     transitionTension={(vx) => {
       // function receives the gestureState vx property
       return vx*100;
     }}
-=======
-    transitionFriction={(vx) => {
-      // function receives the gestureState vx property
-      return vx*100;
-    }}
-    transitionTension={10}
->>>>>>> 69de0a4ca565223a1b7c03adf44944cbcdf2e17a
 />
 ```
 

--- a/ViewPager.js
+++ b/ViewPager.js
@@ -38,6 +38,14 @@ var ViewPager = React.createClass({
     isLoop: PropTypes.bool,
     locked: PropTypes.bool,
     autoPlay: PropTypes.bool,
+    transitionFriction: React.PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.number
+    ]),
+    transitionTension: React.PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.number
+    ]),
   },
 
   getDefaultProps() {
@@ -72,7 +80,7 @@ var ViewPager = React.createClass({
 
       this.props.hasTouch && this.props.hasTouch(false);
 
-      this.movePage(step);
+      this.movePage(step, gestureState.vx);
     }
 
     this._panResponder = PanResponder.create({
@@ -159,7 +167,7 @@ var ViewPager = React.createClass({
     this.movePage(step);
   },
 
-  movePage(step) {
+  movePage(step, vx) {
     var pageCount = this.props.dataSource.getPageCount();
     var pageNumber = this.state.currentPage + step;
 
@@ -181,17 +189,26 @@ var ViewPager = React.createClass({
       nextChildIdx = 1;
     }
 
-    Animated.spring(this.state.scrollValue, {toValue: scrollStep, friction: 10, tension: 50})
-      .start((event) => {
-        if (event.finished) {
-          this.state.fling = false;
-          this.childIndex = nextChildIdx;
-          this.state.scrollValue.setValue(nextChildIdx);
-          this.setState({
-            currentPage: pageNumber,
-          });
-        }
-      });
+    var friction = (this.props.transitionFriction === 'number') ?
+      this.props.transitionFriction : this.props.transactionFriction(vx);
+
+    var tension = (this.props.transitionTension === 'number') ?
+      this.props.transitionTension : this.props.transactionTension(vx);
+
+    Animated.spring(this.state.scrollValue, {
+      toValue: scrollStep,
+      friction: friction,
+      tension: tension
+    }).start((event) => {
+      if (event.finished) {
+        this.state.fling = false;
+        this.childIndex = nextChildIdx;
+        this.state.scrollValue.setValue(nextChildIdx);
+        this.setState({
+          currentPage: pageNumber,
+        });
+      }
+    });
   },
 
   renderPageIndicator(props) {

--- a/ViewPager.js
+++ b/ViewPager.js
@@ -52,6 +52,8 @@ var ViewPager = React.createClass({
     return {
       isLoop: false,
       locked: false,
+      transitionFriction: 10,
+      transitionTension: 50,
     }
   },
 
@@ -189,11 +191,10 @@ var ViewPager = React.createClass({
       nextChildIdx = 1;
     }
 
-    var friction = (typeof this.props.transitionFriction === 'number') ?
-      this.props.transitionFriction : this.props.transactionFriction(vx) || 10;
-
-    var tension = (typeof this.props.transitionTension === 'number') ?
-      this.props.transitionTension : this.props.transactionTension(vx) || 50;
+    var friction = (typeof this.props.transitionFriction === 'function') ?
+      this.props.transitionFriction(vx) : this.props.transitionFriction;
+    var tension = (typeof this.props.transitionTension === 'function') ?
+      this.props.transitionTension(vx) : this.props.transitionTension;
 
     Animated.spring(this.state.scrollValue, {
       toValue: scrollStep,

--- a/ViewPager.js
+++ b/ViewPager.js
@@ -38,6 +38,14 @@ var ViewPager = React.createClass({
     isLoop: PropTypes.bool,
     locked: PropTypes.bool,
     autoPlay: PropTypes.bool,
+    transitionFriction: React.PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.number
+    ]),
+    transitionTension: React.PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.number
+    ]),
   },
 
   getDefaultProps() {
@@ -72,7 +80,7 @@ var ViewPager = React.createClass({
 
       this.props.hasTouch && this.props.hasTouch(false);
 
-      this.movePage(step);
+      this.movePage(step, gestureState.vx);
     }
 
     this._panResponder = PanResponder.create({
@@ -159,7 +167,7 @@ var ViewPager = React.createClass({
     this.movePage(step);
   },
 
-  movePage(step) {
+  movePage(step, vx) {
     var pageCount = this.props.dataSource.getPageCount();
     var pageNumber = this.state.currentPage + step;
 
@@ -181,17 +189,26 @@ var ViewPager = React.createClass({
       nextChildIdx = 1;
     }
 
-    Animated.spring(this.state.scrollValue, {toValue: scrollStep, friction: 10, tension: 50})
-      .start((event) => {
-        if (event.finished) {
-          this.state.fling = false;
-          this.childIndex = nextChildIdx;
-          this.state.scrollValue.setValue(nextChildIdx);
-          this.setState({
-            currentPage: pageNumber,
-          });
-        }
-      });
+    var friction = (typeof this.props.transitionFriction === 'number') ?
+      this.props.transitionFriction : this.props.transactionFriction(vx) || 10;
+
+    var tension = (typeof this.props.transitionTension === 'number') ?
+      this.props.transitionTension : this.props.transactionTension(vx) || 50;
+
+    Animated.spring(this.state.scrollValue, {
+      toValue: scrollStep,
+      friction: friction,
+      tension: tension
+    }).start((event) => {
+      if (event.finished) {
+        this.state.fling = false;
+        this.childIndex = nextChildIdx;
+        this.state.scrollValue.setValue(nextChildIdx);
+        this.setState({
+          currentPage: pageNumber,
+        });
+      }
+    });
   },
 
   renderPageIndicator(props) {

--- a/ViewPagerDataSource.js
+++ b/ViewPagerDataSource.js
@@ -61,7 +61,7 @@ class ViewPagerDataSource {
   pageShouldUpdate(pageIndex: number): bool {
     var needsUpdate = this._dirtyPages[pageIndex];
     //    warning(needsUpdate !== undefined,
-      'missing dirtyBit for section, page: ' + pageIndex);
+    //  'missing dirtyBit for section, page: ' + pageIndex);
     return needsUpdate;
   }
 


### PR DESCRIPTION
I found myself wanting to set the `friction` and `tension` props on the page transition animations so I forked your repo and added that functionality in the form of adding two properties to the component. 

`transitionFriction` and `transitionTension`, both of which accept a number or a function which returns a number. Numbers are just plugged straight into the animation, functions are passed the vx property of the PanResponder's gestureState (horizontal velocity) so you can run some math with it if you choose.

Like this:

```
<ViewPager
    dataSource={this.state.dataSource}
    renderPage={this._renderPage}
    transitionFriction={10}
    transitionTension={(vx) => {
      // function receives the gestureState vx property
      return vx*100;
    }}
/>
```

I'm pretty new to contributing, and by pretty new I mean this is the first time I've done it with any project so I'm not exactly sure what protocol is here. If I've gone about anything the wrong way please let me know.

Anyways, thanks for making this component, hope my contribution is helpful.
