### PR TITLE
Move onChangePage listener to end of animation

### DIFF
--- a/ViewPager.js
+++ b/ViewPager.js
@@ -172,7 +172,7 @@ var ViewPager = React.createClass({
     var moved = pageNumber !== this.state.currentPage;
     var scrollStep = (moved ? step : 0) + this.childIndex;
 
-    moved && this.props.onChangePage && this.props.onChangePage(pageNumber);
+//    moved && this.props.onChangePage && this.props.onChangePage(pageNumber);
 
     this.state.fling = true;
 
@@ -190,6 +190,7 @@ var ViewPager = React.createClass({
           this.setState({
             currentPage: pageNumber,
           });
+          moved && this.props.onChangePage && this.props.onChangePage(pageNumber);
         }
       });
   },

--- a/ViewPagerDataSource.js
+++ b/ViewPagerDataSource.js
@@ -61,7 +61,7 @@ class ViewPagerDataSource {
   pageShouldUpdate(pageIndex: number): bool {
     var needsUpdate = this._dirtyPages[pageIndex];
     //    warning(needsUpdate !== undefined,
-      'missing dirtyBit for section, page: ' + pageIndex);
+    //  'missing dirtyBit for section, page: ' + pageIndex);
     return needsUpdate;
   }
 


### PR DESCRIPTION
Move onChangePage listener to the end of the animation. I wanted to do some setState in the onChangePage listener, but because the transition hasn't fully finished, the animation does not run smoothly.
