### PR TITLE
Allow custom page transition animation properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ var ViewPager = require('react-native-viewpager');
 
 ## Animated Transition Controls
 
-* **`transitionFriction`**: number or function that returns a number to set custom friction value for animated page transitions.
-* **`transitionTension`**: number or function that returns a number to set custom tension value for animated page transitions.
+* **`animationType`**: 'spring' or 'timing'
+* **`animationProps`**: `object` that holds the necessary properties for the animationType provided. Each property should be of the type expected by the corresponding [React.Animated method](https://facebook.github.io/react-native/docs/animated.html#methods) or a function that accepts the gestureState of the swipe that initiated the transition and returns the expected value type.
 
 Example:
 ```
@@ -48,10 +48,17 @@ var ViewPager = require('react-native-viewpager');
 <ViewPager
     dataSource={this.state.dataSource}
     renderPage={this._renderPage}
-    transitionFriction={10}
-    transitionTension={(vx) => {
-      // function receives the gestureState vx property
-      return vx*100;
+    animationType="timing"
+    animationProps = {{
+      duration: (gs) => {
+        // Use the horizontal velocity of the swipe gesture
+        // to affect the length of the transition so the faster you swipe
+        // the faster the pages will transition
+        var velocity = Math.abs(gs.vx);
+        var baseDuration = 300;
+        return (velocity > 1) ? 1/velocity * baseDuration : baseDuration;
+      },
+      easing: Easing.out(Easing.exp)
     }}
 />
 ```

--- a/README.md
+++ b/README.md
@@ -37,10 +37,9 @@ var ViewPager = require('react-native-viewpager');
 * **`onChangePage`**: page change callback,
 * **`renderPageIndicator`**: render custom ViewPager indicator.
 
-## Animated Transition Controls
+## Page Transition Animation Controls
 
-* **`animationType`**: 'spring' or 'timing'
-* **`animationProps`**: `object` that holds the necessary properties for the animationType provided. Each property should be of the type expected by the corresponding [React.Animated method](https://facebook.github.io/react-native/docs/animated.html#methods) or a function that accepts the gestureState of the swipe that initiated the transition and returns the expected value type.
+* **`animation`**: function that returns a React Native Animated configuration.
 
 Example:
 ```
@@ -48,18 +47,21 @@ var ViewPager = require('react-native-viewpager');
 <ViewPager
     dataSource={this.state.dataSource}
     renderPage={this._renderPage}
-    animationType="timing"
-    animationProps = {{
-      duration: (gs) => {
-        // Use the horizontal velocity of the swipe gesture
-        // to affect the length of the transition so the faster you swipe
-        // the faster the pages will transition
-        var velocity = Math.abs(gs.vx);
-        var baseDuration = 300;
-        return (velocity > 1) ? 1/velocity * baseDuration : baseDuration;
-      },
+    animation = {(animatedValue, toValue, gestureState) => {
+    // Use the horizontal velocity of the swipe gesture
+    // to affect the length of the transition so the faster you swipe
+    // the faster the pages will transition
+    var velocity = Math.abs(gestureState.vx);
+    var baseDuration = 300;
+    var duration = (velocity > 1) ? 1/velocity * baseDuration : baseDuration;
+
+    return Animated.timing(animatedValue,
+    {
+      toValue: toValue,
+      duration: duration,
       easing: Easing.out(Easing.exp)
-    }}
+    });
+  }}
 />
 ```
 

--- a/ViewPager.js
+++ b/ViewPager.js
@@ -38,21 +38,21 @@ var ViewPager = React.createClass({
     isLoop: PropTypes.bool,
     locked: PropTypes.bool,
     autoPlay: PropTypes.bool,
-    animationType: PropTypes.oneOf(['timing', 'spring']),
-    animationProps: PropTypes.object,
+    animation: PropTypes.func,
   },
 
   getDefaultProps() {
     return {
       isLoop: false,
       locked: false,
-      animationType: 'spring',
-      animationProps: [
-        {
-          friction: 10,
-          tension: 50,
-        }
-      ],
+      animation: function(animate, toValue, gs) {
+        return Animated.spring(animate,
+          {
+            toValue: toValue,
+            friction: 10,
+            tension: 50,
+          })
+      },
     }
   },
 
@@ -188,16 +188,7 @@ var ViewPager = React.createClass({
       nextChildIdx = 1;
     }
 
-    // Iterate through animation props and build an object
-    // If any props are functions pass them the gestureState
-    // and store their responses
-    var animationProps = Object.keys(this.props.animationProps).reduce((prev, prop) => {
-      prev[prop] =  (typeof this.props.animationProps[prop] === 'function') ?
-        this.props.animationProps[prop](gs) : this.props.animationProps[prop];
-      return prev;
-    }, { toValue: scrollStep });
-
-    Animated[this.props.animationType](this.state.scrollValue, animationProps)
+    this.props.animation(this.state.scrollValue, scrollStep, gs)
       .start((event) => {
         if (event.finished) {
           this.state.fling = false;
@@ -209,6 +200,8 @@ var ViewPager = React.createClass({
         }
         moved && this.props.onChangePage && this.props.onChangePage(pageNumber);
       });
+
+
   },
 
   renderPageIndicator(props) {

--- a/ViewPager.js
+++ b/ViewPager.js
@@ -38,21 +38,21 @@ var ViewPager = React.createClass({
     isLoop: PropTypes.bool,
     locked: PropTypes.bool,
     autoPlay: PropTypes.bool,
-    animationType: PropTypes.oneOf(['timing', 'spring']),
-    animationProps: PropTypes.object,
+    animation: PropTypes.func,
   },
 
   getDefaultProps() {
     return {
       isLoop: false,
       locked: false,
-      animationType: 'spring',
-      animationProps: [
-        {
-          friction: 10,
-          tension: 50,
-        }
-      ],
+      animation: function(animate, toValue, gs) {
+        return Animated.spring(animate,
+          {
+            toValue: toValue,
+            friction: 10,
+            tension: 50,
+          })
+      },
     }
   },
 
@@ -190,16 +190,7 @@ var ViewPager = React.createClass({
       nextChildIdx = 1;
     }
 
-    // Iterate through animation props and build an object
-    // If any props are functions pass them the gestureState
-    // and store their responses
-    var animationProps = Object.keys(this.props.animationProps).reduce((prev, prop) => {
-      prev[prop] =  (typeof this.props.animationProps[prop] === 'function') ?
-        this.props.animationProps[prop](gs) : this.props.animationProps[prop];
-      return prev;
-    }, { toValue: scrollStep });
-
-    Animated[this.props.animationType](this.state.scrollValue, animationProps)
+    this.props.animation(this.state.scrollValue, scrollStep, gs)
       .start((event) => {
         if (event.finished) {
           this.state.fling = false;
@@ -210,6 +201,8 @@ var ViewPager = React.createClass({
           });
         }
       });
+
+
   },
 
   renderPageIndicator(props) {

--- a/ViewPager.js
+++ b/ViewPager.js
@@ -236,7 +236,8 @@ var ViewPager = React.createClass({
         render={this.props.renderPage.bind(
           null,
           dataSource.getPageData(pageIdx),
-          pageID
+          pageID,
+          this.state.currentPage
         )}
       />
     );

--- a/ViewPager.js
+++ b/ViewPager.js
@@ -235,7 +235,8 @@ var ViewPager = React.createClass({
         render={this.props.renderPage.bind(
           null,
           dataSource.getPageData(pageIdx),
-          pageID
+          pageID,
+          this.state.currentPage
         )}
       />
     );

--- a/ViewPager.js
+++ b/ViewPager.js
@@ -31,29 +31,28 @@ var ViewPager = React.createClass({
     dataSource: PropTypes.instanceOf(ViewPagerDataSource).isRequired,
     renderPage: PropTypes.func.isRequired,
     onChangePage: PropTypes.func,
-    renderPageIndicator: React.PropTypes.oneOfType([
+    renderPageIndicator: PropTypes.oneOfType([
       PropTypes.func,
       PropTypes.bool
     ]),
     isLoop: PropTypes.bool,
     locked: PropTypes.bool,
     autoPlay: PropTypes.bool,
-    transitionFriction: React.PropTypes.oneOfType([
-      PropTypes.func,
-      PropTypes.number
-    ]),
-    transitionTension: React.PropTypes.oneOfType([
-      PropTypes.func,
-      PropTypes.number
-    ]),
+    animationType: PropTypes.oneOf(['timing', 'spring']),
+    animationProps: PropTypes.object,
   },
 
   getDefaultProps() {
     return {
       isLoop: false,
       locked: false,
-      transitionFriction: 10,
-      transitionTension: 50,
+      animationType: 'spring',
+      animationProps: [
+        {
+          friction: 10,
+          tension: 50,
+        }
+      ],
     }
   },
 
@@ -82,7 +81,7 @@ var ViewPager = React.createClass({
 
       this.props.hasTouch && this.props.hasTouch(false);
 
-      this.movePage(step, gestureState.vx);
+      this.movePage(step, gestureState);
     }
 
     this._panResponder = PanResponder.create({
@@ -169,7 +168,7 @@ var ViewPager = React.createClass({
     this.movePage(step);
   },
 
-  movePage(step, vx) {
+  movePage(step, gs) {
     var pageCount = this.props.dataSource.getPageCount();
     var pageNumber = this.state.currentPage + step;
 
@@ -191,25 +190,26 @@ var ViewPager = React.createClass({
       nextChildIdx = 1;
     }
 
-    var friction = (typeof this.props.transitionFriction === 'function') ?
-      this.props.transitionFriction(vx) : this.props.transitionFriction;
-    var tension = (typeof this.props.transitionTension === 'function') ?
-      this.props.transitionTension(vx) : this.props.transitionTension;
+    // Iterate through animation props and build an object
+    // If any props are functions pass them the gestureState
+    // and store their responses
+    var animationProps = Object.keys(this.props.animationProps).reduce((prev, prop) => {
+      prev[prop] =  (typeof this.props.animationProps[prop] === 'function') ?
+        this.props.animationProps[prop](gs) : this.props.animationProps[prop];
+      return prev;
+    }, { toValue: scrollStep });
 
-    Animated.spring(this.state.scrollValue, {
-      toValue: scrollStep,
-      friction: friction,
-      tension: tension
-    }).start((event) => {
-      if (event.finished) {
-        this.state.fling = false;
-        this.childIndex = nextChildIdx;
-        this.state.scrollValue.setValue(nextChildIdx);
-        this.setState({
-          currentPage: pageNumber,
-        });
-      }
-    });
+    Animated[this.props.animationType](this.state.scrollValue, animationProps)
+      .start((event) => {
+        if (event.finished) {
+          this.state.fling = false;
+          this.childIndex = nextChildIdx;
+          this.state.scrollValue.setValue(nextChildIdx);
+          this.setState({
+            currentPage: pageNumber,
+          });
+        }
+      });
   },
 
   renderPageIndicator(props) {


### PR DESCRIPTION
Resolves issue #31 by adding an animation property to ViewPager which accepts a function that returns a React Native Animated configuration.

I also added in a bit of code to send the current page index to the renderPage function as a third property. This has been very helpful in my project, I'm open to discussion about leaving that in or taking it out, what do you think?
