### PR TITLE
Add `willChangePage'.

### DIFF
--- a/ViewPager.js
+++ b/ViewPager.js
@@ -30,6 +30,7 @@ var ViewPager = React.createClass({
     ...View.propTypes,
     dataSource: PropTypes.instanceOf(ViewPagerDataSource).isRequired,
     renderPage: PropTypes.func.isRequired,
+    willChangePage: PropTypes.func,
     onChangePage: PropTypes.func,
     renderPageIndicator: PropTypes.oneOfType([
       PropTypes.func,
@@ -189,7 +190,9 @@ var ViewPager = React.createClass({
     if (pageNumber > 0 || this.props.isLoop) {
       nextChildIdx = 1;
     }
-
+    
+    moved && this.props.willChangePage && this.props.willChangePage(pageNumber);
+    
     this.props.animation(this.state.scrollValue, scrollStep, gs)
       .start((event) => {
         if (event.finished) {

--- a/ViewPager.js
+++ b/ViewPager.js
@@ -87,15 +87,19 @@ var ViewPager = React.createClass({
       this.movePage(step, gestureState);
     }
 
+    var pageCount = this.props.dataSource.getPageCount();
+
     this._panResponder = PanResponder.create({
       // Claim responder if it's a horizontal pan
       onMoveShouldSetPanResponder: (e, gestureState) => {
         if (Math.abs(gestureState.dx) > Math.abs(gestureState.dy)) {
-          if (/* (gestureState.moveX <= this.props.edgeHitWidth ||
-              gestureState.moveX >= deviceWidth - this.props.edgeHitWidth) && */
-                this.props.locked !== true && !this.fling) {
-            this.props.hasTouch && this.props.hasTouch(true);
-            return true;
+          if (this.props.locked !== true && !this.fling) {
+            // prevent swiping left of first page, and right of last page
+            if (!(gestureState.dx > 0 && this.getCurrentPage() == 0) &&
+                !(gestureState.dx < 0 && this.getCurrentPage() == pageCount - 1)) {
+              this.props.hasTouch && this.props.hasTouch(true);
+              return true;
+            }
           }
         }
       },


### PR DESCRIPTION
Currently, other animations in the app have to bind to the `onChangePage', which makes them lag behind the page change animation. This commit adds in a`willChangePage', which allows functions to be executed right before the start of the page change animation.
