### PR TITLE
Fixed deprecation warnings for React Native 0.25

### DIFF
--- a/DefaultViewPageIndicator.js
+++ b/DefaultViewPageIndicator.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var React = require('react-native');
+var React = require('react');
+var ReactNative = require('react-native');
 var {
   Dimensions,
   StyleSheet,
@@ -8,7 +9,7 @@ var {
   TouchableOpacity,
   View,
   Animated,
-} = React;
+} = ReactNative;
 
 var deviceWidth = Dimensions.get('window').width;
 var DOT_SIZE = 6;

--- a/ViewPager.js
+++ b/ViewPager.js
@@ -1,6 +1,9 @@
 'use strict';
 
-var React = require('react-native');
+var React = require('react');
+var { PropTypes } = React;
+
+var ReactNative = require('react-native');
 var {
   Dimensions,
   Text,
@@ -8,9 +11,8 @@ var {
   TouchableOpacity,
   PanResponder,
   Animated,
-  PropTypes,
   StyleSheet,
-} = React;
+} = ReactNative;
 
 var StaticRenderer = require('react-native/Libraries/Components/StaticRenderer');
 var TimerMixin = require('react-timer-mixin');


### PR DESCRIPTION
Importing React, PropTypes, and Component from the 'react-native' packages will be completely removed in React Native 0.26.
