### PR TITLE
Splits react-native and react to avoid warnings on >= 0.25

### DIFF
--- a/DefaultViewPageIndicator.js
+++ b/DefaultViewPageIndicator.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var React = require('react-native');
+var React = require('react');
+var ReactNative = require('react-native');
 var {
   Dimensions,
   StyleSheet,
@@ -8,7 +9,7 @@ var {
   TouchableOpacity,
   View,
   Animated,
-} = React;
+} = ReactNative;
 
 var deviceWidth = Dimensions.get('window').width;
 var DOT_SIZE = 6;

--- a/ViewPager.js
+++ b/ViewPager.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var React = require('react-native');
+var React = require('react');
+var ReactNative = require('react-native');
 var {
   Dimensions,
   Text,
@@ -10,7 +11,7 @@ var {
   Animated,
   PropTypes,
   StyleSheet,
-} = React;
+} = ReactNative;
 
 var StaticRenderer = require('react-native/Libraries/Components/StaticRenderer');
 var TimerMixin = require('react-timer-mixin');


### PR DESCRIPTION
[Starting from 0.25, creating components from 'react-native' is a deprecated.](https://github.com/facebook/react-native/releases/tag/v0.25.1)

This pull request avoids warnings on this version.
