### PR TITLE
Fixed threshold speed for quick forward move

### DIFF
--- a/ViewPager.js
+++ b/ViewPager.js
@@ -75,7 +75,7 @@ var ViewPager = React.createClass({
           vx = gestureState.vx;
 
       var step = 0;
-      if (relativeGestureDistance < -0.5 || (relativeGestureDistance < 0 && vx <= 0.5)) {
+      if (relativeGestureDistance < -0.5 || (relativeGestureDistance < 0 && vx <= -0.5)) {
         step = 1;
       } else if (relativeGestureDistance > 0.5 || (relativeGestureDistance > 0 && vx >= 0.5)) {
         step = -1;


### PR DESCRIPTION
When moving forward the speed is always negative, the check `vx <= 0.5` caused the page to change after a 1px drag.
