### PR TITLE
Reset fling when properties change

### DIFF
--- a/ViewPager.js
+++ b/ViewPager.js
@@ -145,6 +145,7 @@ var ViewPager = React.createClass({
       }
 
       this.childIndex = Math.min(this.childIndex, constrainedPage);
+      this.fling = false;
     }
 
   },


### PR DESCRIPTION
Otherwise the animation may never end and the fling status will be locked to 'true' which will prevent page changes. I encountered this problem when I was observing gestures happening within the pager and tried to set the property lock accordingly.
