### PR TITLE
Fix Flow annotation for babylon 6.10

### DIFF
--- a/ViewPager.js
+++ b/ViewPager.js
@@ -235,7 +235,7 @@ var ViewPager = React.createClass({
     }
   },
 
-  _getPage(pageIdx: number, loop = false: boolean) {
+  _getPage(pageIdx: number, loop: boolean = false) {
     var dataSource = this.props.dataSource;
     var pageID = dataSource.pageIdentities[pageIdx];
     return (


### PR DESCRIPTION
annotations must come before default assignments, per https://github.com/babel/babylon/commit/64145b07e32cc9c5a1c164ca6c93a9ed5b363576
