### PR TITLE
Type Annotations must come before default assign..

### DIFF
--- a/ViewPager.js
+++ b/ViewPager.js
@@ -235,7 +235,7 @@ var ViewPager = React.createClass({
     }
   },
 
-  _getPage(pageIdx: number, loop = false: boolean) {
+  _getPage(pageIdx: number, loop:boolean = false ) {
     var dataSource = this.props.dataSource;
     var pageID = dataSource.pageIdentities[pageIdx];
     return (


### PR DESCRIPTION
Fix Type Annotations must come before default assignments. When importing the packages
![image](https://cloud.githubusercontent.com/assets/1866811/18757188/5965547e-80e2-11e6-9285-ff8edc4d04e6.png)
