### PR TITLE
fix the warning when dataSource.length = 1

### DIFF
--- a/ViewPager.js
+++ b/ViewPager.js
@@ -279,12 +279,14 @@ var ViewPager = React.createClass({
       pagesNum++;
 
       // right page
-      if (this.state.currentPage < pageIDs.length - 1) {
-        bodyComponents.push(this._getPage(this.state.currentPage + 1));
-        pagesNum++;
-      } else if (this.state.currentPage == pageIDs.length - 1 && this.props.isLoop) {
-        bodyComponents.push(this._getPage(0, true));
-        pagesNum++;
+      if (pageIDs.length > 1) {
+        if (this.state.currentPage < pageIDs.length - 1) {
+          bodyComponents.push(this._getPage(this.state.currentPage + 1));
+          pagesNum++;
+        } else if (this.state.currentPage == pageIDs.length - 1 && this.props.isLoop) {
+          bodyComponents.push(this._getPage(0, true));
+          pagesNum++;
+        }
       }
     }
 


### PR DESCRIPTION
当dataSource只有一条的时候，会不停的报warning：“ExceptionsManager.js:82 Warning: flattenChildren(...): Encountered two children with the same key, `p_0_1`. Child keys must be unique; when two children share a key, only the first child will be used.”。这个pr解决了这个问题
