### PR TITLE
#126 support cell bleeding (non full width cell item)

### DIFF
--- a/ViewPager.js
+++ b/ViewPager.js
@@ -42,6 +42,7 @@ var ViewPager = React.createClass({
     autoPlay: PropTypes.bool,
     animation: PropTypes.func,
     initialPage: PropTypes.number,
+    itemWidth: PropTypes.number
   },
 
   fling: false,
@@ -111,7 +112,7 @@ var ViewPager = React.createClass({
         var dx = gestureState.dx;
         var offsetX = -dx / this.state.viewWidth + this.childIndex;
         this.state.scrollValue.setValue(offsetX);
-      },
+      }
     });
 
     if (this.props.isLoop) {
@@ -304,13 +305,13 @@ var ViewPager = React.createClass({
       <View style={{flex: 1}}
         onLayout={(event) => {
             // console.log('ViewPager.onLayout()');
-            var viewWidth = event.nativeEvent.layout.width;
+            var viewWidth = this.props.itemWidth || event.nativeEvent.layout.width;
             if (!viewWidth || this.state.viewWidth === viewWidth) {
               return;
             }
             this.setState({
               currentPage: this.state.currentPage,
-              viewWidth: viewWidth,
+              viewWidth: viewWidth
             });
           }}
         >


### PR DESCRIPTION
Solve issue #126 

- Add optional itemWidth props to override viewWidth, to support bleeding ( non full width cell item).